### PR TITLE
Persist Iot messages in DynamoDB

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,2 @@
+language: node_js
+cache: yarn

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,4 @@
 language: node_js
+node_js:
+  - "6"
 cache: yarn

--- a/serverless.yml
+++ b/serverless.yml
@@ -4,20 +4,23 @@ service: serverless-slack
 # Check out our docs for more details
 frameworkVersion: "=1.7.0"
 
+custom:
+  defaultRegion: us-east-1
+  defaultStage: dev
+  webpackIncludeModules: true # enable auto-packing of external modules
+
 provider:
-  name: aws
-  runtime: nodejs4.3
-  stage: ${opt:stage, self:custom.defaultStage}
-  profile: serverless-slack
-  region: us-east-1
+  environment:
+    DYNAMODB_TABLE: ${{self:service}}-${{self:provider.stage}}-messages
   memorySize: 256
+  name: aws
+  profile: serverless-slack
+  region: ${{opt:region, self:custom.defaultRegion}}
+  runtime: nodejs4.3
+  stage: ${{opt:stage, self:custom.defaultStage}}
   timeout: 30
+  variableSyntax: '\${{([\s\S]+?)}}'
   iamRoleStatements:
-    - Effect: "Allow"
-      Action:
-        - "sdb:PutAttributes"
-        - "sdb:Select"
-      Resource: "arn:aws:sdb:${self:provider.region}:*:domain/serverless-slack-iot"
     - Effect: "Allow"
       Action:
         - "iot:DescribeEndpoint"
@@ -26,6 +29,15 @@ provider:
       Action:
         - "sts:AssumeRole"
       Resource: "*"
+    - Effect: Allow
+      Action:
+        - dynamodb:Query
+        - dynamodb:Scan
+        - dynamodb:GetItem
+        - dynamodb:PutItem
+        - dynamodb:UpdateItem
+        - dynamodb:DeleteItem
+      Resource: "arn:aws:dynamodb:${{self:provider.region}}:*:table/${{self:provider.environment.DYNAMODB_TABLE}}"
 
 functions:
   iotKeys:
@@ -35,9 +47,75 @@ functions:
           path: iot/keys
           method: get
 
-custom:
-  defaultStage: dev
-  webpackIncludeModules: true # enable auto-packing of external modules
+resources:
+  Resources:
+    ServerlessSlackMessages:
+      Type: AWS::DynamoDB::Table
+      DeletionPolicy: Retain
+      Properties:
+        TableName: ${{self:provider.environment.DYNAMODB_TABLE}}
+        AttributeDefinitions:
+          -
+            AttributeName: Topic
+            AttributeType: S
+          -
+            AttributeName: Timestamp
+            AttributeType: S
+        KeySchema:
+          -
+            AttributeName: Topic
+            KeyType: HASH
+          -
+            AttributeName: Timestamp
+            KeyType: RANGE
+        ProvisionedThroughput:
+          ReadCapacityUnits: 1
+          WriteCapacityUnits: 1
+
+
+    IoTRole:
+     Type: AWS::IAM::Role
+     Properties:
+        AssumeRolePolicyDocument:
+          Version: "2012-10-17"
+          Statement:
+            -
+              Effect: Allow
+              Principal:
+                Service:
+                  - iot.amazonaws.com
+              Action:
+                - sts:AssumeRole
+
+    IoTRolePolicies:
+      Type: AWS::IAM::Policy
+      Properties:
+        PolicyName: IoTRole_Policy
+        PolicyDocument:
+          Version: "2012-10-17"
+          Statement:
+            -
+              Effect: Allow
+              Action:
+                - dynamodb:PutItem
+              Resource: "*"
+        Roles: [{ Ref: IoTRole }]
+
+    IoTToDyanmoDBRule:
+      Type: AWS::IoT::TopicRule
+      Properties:
+        TopicRulePayload:
+          RuleDisabled: false
+          Sql: "SELECT * FROM '${{self:provider.stage}}/serverlessslack/chat'"
+          Actions:
+            -
+              DynamoDB:
+                TableName: { Ref: ServerlessSlackMessages }
+                HashKeyField: "Topic"
+                HashKeyValue: "${topic()}"
+                RangeKeyField: "Timestamp"
+                RangeKeyValue: "${timestamp()}"
+                RoleArn: { Fn::GetAtt: [ IoTRole, Arn ] }
 
 plugins:
   - serverless-webpack


### PR DESCRIPTION
Update `serverless.yml` to set up an `IoT` rule to store all incoming messages in `DyanmoDB` with `Topic`, `Timestamp`, and `Payload`